### PR TITLE
Update the 1.1.5 branch to provide a native target and dependency.

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -23,141 +23,182 @@ project(
 
 lib_version = '0.5.0'
 
-cc = meson.get_compiler('c')
-
-if ['gcc', 'clang'].contains(cc.get_id())
-  add_project_arguments(
-    # I've explicitly skipped the duplicated -W versions when they also test
-    # for the -Werror version
-    cc.get_supported_arguments(
-      '-Wshadow',
-      '-Wmissing-prototypes',
-      '-Wcast-align',
-      '-Werror=address',
-      '-Werror=strict-prototypes',
-      '-Werror=write-strings',
-      '-Werror=implicit-function-declaration',
-      '-Werror=pointer-arith',
-      '-Werror=declaration-after-statement',
-      '-Werror=return-type',
-      '-Werror=uninitialized',
-      '-Wimplicit-fallthrough',
-      '-Werror=strict-overflow',
-      '-Wstrict-overflow=2',
-      '-Wno-format-zero-length',
-      '-Wformat',
-      '-Werror=format-security',
-      '-Wno-gnu-zero-variadic-macro-arguments',
-      '-fno-common',
-    ),
-    language : ['c'],
-  )
-  # We can't test the build type, so we can' add -D_FORTIFY_SOURCE=2 here
-  if host_machine.system() == 'darwin'
-    if cc.has_argument('-Wno-deprecated-declarations')
-      add_project_arguments('-Wno-deprecated-declarations', language : ['c'])
-    endif
-  endif
-elif cc.get_id() == 'msvc'
-  add_project_arguments(
-    '/D_CRT_SECURE_CPP_OVERLOAD_STANDARD_NAMES=1',
-    '/D_CRT_SECURE_CPP_OVERLOAD_STANDARD_NAMES_COUNT=1',
-    '/D_CRT_NONSTDC_NO_WARNINGS=1',
-    '/D_CRT_SECURE_NO_WARNINGS=1',
-    language : ['c'],
-  )
-endif
-
-# TODO: solaris extensions
-
-conf = configuration_data()
-
-foreach h : ['assert.h', 'inttypes.h', 'io.h', 'malloc.h', 'memory.h',
-             'setjmp.h', 'signal.h', 'stdarg.h', 'stddef.h', 'stdint.h',
-             'stdio.h', 'stdlib.h', 'string.h', 'strings.h', 'sys/stat.h',
-             'sys/types.h', 'time.h', 'unistd.h']
-  if cc.check_header(h)
-    conf.set('HAVE_@0@'.format(h.underscorify().to_upper()), 1)
-  endif
-endforeach
-
-if conf.get('HAVE_TIME_H', 0) == 1
-  if cc.has_member('struct timespec', 'tv_sec', prefix : '#include <time.h>')
-    conf.set('HAVE_STRUCT_TIMESPEC', 1)
-  endif
-endif
-
-foreach f : ['calloc', 'exit', 'fprintf', 'free', 'longjmp', 'siglongjmp',
-             'malloc', 'memcpy', 'memset', 'printf', 'setjmp', 'signal',
-             'strsignal', 'strcmp', 'clock_gettime']
-  if cc.has_function(f)
-    conf.set('HAVE_@0@'.format(f.underscorify().to_upper()), 1)
-  endif
-endforeach
-
-if host_machine.system() == 'windows'
-  foreach f : ['_vsnprintf_s', '_vsnprtinf', '_snprintf_s', '_snprintf']
-    if cc.has_function(f)
-      conf.set('HAVE_@0@'.format(f.underscorify().to_upper()), 1)
-    endif
-  endforeach
-  foreach f : ['snprintf', 'vsnprintf']
-    if cc.has_header_symbol('stdio.h', f)
-      conf.set('HAVE_@0@'.format(f.underscorify().to_upper()), 1)
-    endif
-  endforeach
-else
-  foreach f : ['snprintf', 'vsnprintf']
-    if cc.has_function(f)
-      conf.set('HAVE_@0@'.format(f.underscorify().to_upper()), 1)
-    endif
-  endforeach
-endif
-
-if host_machine.system() == 'windows'
-  if cc.compiles('''
-      __declspec(thread) int tls;
-
-      int main(void) {
-        return 0;
-      }''',
-      name : 'Thread Local Storage')
-    conf.set('HAVE_MSVC_THREAD_LOCAL_STORAGE', 1)
-  endif
-else
-  if cc.compiles('''
-      __thread int tls;
-
-      int main(void) {
-        return 0;
-      }''',
-      name : 'Thread Local Storage')
-    conf.set('HAVE_GCC_THREAD_LOCAL_STORAGE', 1)
-  endif
-endif
-
-dep_rt = cc.find_library('rt', required : false)
-
-if (conf.get('HAVE_TIME_H', 0) == 1 and
-    conf.get('HAVE_STRUCT_TIMESPEC', 0) == 1 and
-    conf.get('HAVE_CLOCK_GETTIME', 0) == 1)
-  if cc.has_header_symbol('time.h', 'CLOCK_REALTIME')
-    conf.set('HAVE_CLOCK_REALTIME', 1)
-  endif
-endif  
-
-conf.set('WORDS_SIZEOF_VOID_P', cc.sizeof('void *'))
-if host_machine.endian() == 'big'
-  conf.set('WORDS_BIGENDIAN', 1)
-endif
-
 # TODO: pkg-config
 # TODO: cmake-config
 
 inc_include = include_directories('include')
 
+#####################
+# Config Generation #
+#####################
+
+cc = meson.get_compiler('c')
+cc_native = meson.get_compiler('c', native: true)
+
+conf = configuration_data()
+conf_native = configuration_data()
+
+cc_dict = {
+    'compiler': cc,
+    'machine': host_machine,
+    'config': conf,
+    'native': false
+}
+
+cc_native_dict = {
+    'compiler': cc_native,
+    'machine': build_machine,
+    'config': conf_native,
+    'native': true
+}
+
+configurations = [cc_dict, cc_native_dict]
+
+foreach entry : configurations
+  compiler = entry.get('compiler')
+  config = entry.get('config')
+  n = entry.get('native')
+  machine = entry.get('machine')
+
+  if ['gcc_native', 'clang'].contains(compiler.get_id())
+    add_project_arguments(
+      # I've explicitly skipped the duplicated -W versions when they also test
+      # for the -Werror version
+      compiler.get_supported_arguments(
+        '-Wshadow',
+        '-Wmissing-prototypes',
+        '-Wcast-align',
+        '-Werror=address',
+        '-Werror=strict-prototypes',
+        '-Werror=write-strings',
+        '-Werror=implicit-function-declaration',
+        '-Werror=pointer-arith',
+        '-Werror=declaration-after-statement',
+        '-Werror=return-type',
+        '-Werror=uninitialized',
+        '-Wimplicit-fallthrough',
+        '-Werror=strict-overflow',
+        '-Wstrict-overflow=2',
+        '-Wno-format-zero-length',
+        '-Wformat',
+        '-Werror=format-security',
+        '-Wno-gnu-zero-variadic-macro-arguments',
+        '-fno-common',
+      ),
+      language : ['c'],
+      native: n
+    )
+    # We can't test the build type, so we can' add -D_FORTIFY_SOURCE=2 here
+    if machine.system() == 'darwin'
+      if compiler.has_argument('-Wno-deprecated-declarations')
+        add_project_arguments('-Wno-deprecated-declarations', language : ['c'], native: n)
+      endif
+    endif
+  elif compiler.get_id() == 'msvc'
+    add_project_arguments(
+      '/D_CRT_SECURE_CPP_OVERLOAD_STANDARD_NAMES=1',
+      '/D_CRT_SECURE_CPP_OVERLOAD_STANDARD_NAMES_COUNT=1',
+      '/D_CRT_NONSTDC_NO_WARNINGS=1',
+      '/D_CRT_SECURE_NO_WARNINGS=1',
+      language : ['c'],
+      native: n
+    )
+  endif
+
+  # TODO: solaris extensions
+
+  foreach h : ['assert.h', 'inttypes.h', 'io.h', 'malloc.h', 'memory.h',
+               'setjmp.h', 'signal.h', 'stdarg.h', 'stddef.h', 'stdint.h',
+               'stdio.h', 'stdlib.h', 'string.h', 'strings.h', 'sys/stat.h',
+               'sys/types.h', 'time.h', 'unistd.h']
+    if compiler.check_header(h)
+      config.set('HAVE_@0@'.format(h.underscorify().to_upper()), 1)
+    endif
+  endforeach
+
+  if config.get('HAVE_TIME_H', 0) == 1
+    if compiler.has_member('struct timespec', 'tv_sec', prefix : '#include <time.h>')
+      config.set('HAVE_STRUCT_TIMESPEC', 1)
+    endif
+  endif
+
+  foreach f : ['calloc', 'exit', 'fprintf', 'free', 'longjmp', 'siglongjmp',
+               'malloc', 'memcpy', 'memset', 'printf', 'setjmp', 'signal',
+               'strsignal', 'strcmp', 'clock_gettime']
+    if compiler.has_function(f)
+      config.set('HAVE_@0@'.format(f.underscorify().to_upper()), 1)
+    endif
+  endforeach
+
+  if machine.system() == 'windows'
+  foreach f : ['_vsnprintf_s', '_vsnprtinf', '_snprintf_s', '_snprintf']
+    if compiler.has_function(f)
+      config.set('HAVE_@0@'.format(f.underscorify().to_upper()), 1)
+    endif
+  endforeach
+  foreach f : ['snprintf', 'vsnprintf']
+    if compiler.has_header_symbol('stdio.h', f)
+      config.set('HAVE_@0@'.format(f.underscorify().to_upper()), 1)
+    endif
+  endforeach
+else
+  foreach f : ['snprintf', 'vsnprintf']
+    if compiler.has_function(f)
+      config.set('HAVE_@0@'.format(f.underscorify().to_upper()), 1)
+    endif
+  endforeach
+endif
+
+  if machine.system() == 'windows'
+    if compiler.compiles('''
+        __declspec(thread) int tls;
+
+        int main(void) {
+          return 0;
+        }''',
+        name : 'Thread Local Storage')
+      config.set('HAVE_MSVC_THREAD_LOCAL_STORAGE', 1)
+    endif
+  else
+    if compiler.compiles('''
+        __thread int tls;
+
+        int main(void) {
+          return 0;
+        }''',
+        name : 'Thread Local Storage')
+      config.set('HAVE_GCC_THREAD_LOCAL_STORAGE', 1)
+    endif
+  endif
+
+  dep_rt = compiler.find_library('rt', required : false)
+
+  if (config.get('HAVE_TIME_H', 0) == 1 and
+      config.get('HAVE_STRUCT_TIMESPEC', 0) == 1 and
+      config.get('HAVE_CLOCK_GETTIME', 0) == 1)
+    if compiler.has_header_symbol('time.h', 'CLOCK_REALTIME')
+      config.set('HAVE_CLOCK_REALTIME', 1)
+    endif
+  endif
+
+  config.set('WORDS_SIZEOF_VOID_P', compiler.sizeof('void *'))
+  if machine.endian() == 'big'
+    config.set('WORDS_BIGENDIAN', 1)
+  endif
+
+endforeach
+
+###########################
+# Subdirectory Processing #
+###########################
+
 subdir('private')  # someplace safe to put the generated config.h file
+subdir('private_native') # someplace safe to put the generated config.h file for native: true
 subdir('src')
+
+######################
+# Dependency Targets #
+######################
 
 # TODO: doc, include, tests, example
 # Since we're using this as a wrap, and it's a unit test framework we're not
@@ -165,6 +206,12 @@ subdir('src')
 
 cmocka_dep = declare_dependency(
   link_with : libcmocka,
+  include_directories : inc_include,
+  version : meson.project_version(),
+)
+
+cmocka_native_dep = declare_dependency(
+  link_with : libcmocka_native,
   include_directories : inc_include,
   version : meson.project_version(),
 )

--- a/meson.build
+++ b/meson.build
@@ -32,21 +32,18 @@ inc_include = include_directories('include')
 # Config Generation #
 #####################
 
-cc = meson.get_compiler('c')
-cc_native = meson.get_compiler('c', native: true)
-
 conf = configuration_data()
 conf_native = configuration_data()
 
 cc_dict = {
-    'compiler': cc,
+    'compiler': meson.get_compiler('c'),
     'machine': host_machine,
     'config': conf,
     'native': false
 }
 
 cc_native_dict = {
-    'compiler': cc_native,
+    'compiler': meson.get_compiler('c', native: true),
     'machine': build_machine,
     'config': conf_native,
     'native': true
@@ -57,10 +54,10 @@ configurations = [cc_dict, cc_native_dict]
 foreach entry : configurations
   compiler = entry.get('compiler')
   config = entry.get('config')
-  n = entry.get('native')
+  is_native = entry.get('native')
   machine = entry.get('machine')
 
-  if ['gcc_native', 'clang'].contains(compiler.get_id())
+  if ['gcc', 'clang'].contains(compiler.get_id())
     add_project_arguments(
       # I've explicitly skipped the duplicated -W versions when they also test
       # for the -Werror version
@@ -86,12 +83,12 @@ foreach entry : configurations
         '-fno-common',
       ),
       language : ['c'],
-      native: n
+      native: is_native
     )
     # We can't test the build type, so we can' add -D_FORTIFY_SOURCE=2 here
     if machine.system() == 'darwin'
       if compiler.has_argument('-Wno-deprecated-declarations')
-        add_project_arguments('-Wno-deprecated-declarations', language : ['c'], native: n)
+        add_project_arguments('-Wno-deprecated-declarations', language : ['c'], native: is_native)
       endif
     endif
   elif compiler.get_id() == 'msvc'
@@ -101,7 +98,7 @@ foreach entry : configurations
       '/D_CRT_NONSTDC_NO_WARNINGS=1',
       '/D_CRT_SECURE_NO_WARNINGS=1',
       language : ['c'],
-      native: n
+      native: is_native
     )
   endif
 
@@ -170,8 +167,6 @@ endif
       config.set('HAVE_GCC_THREAD_LOCAL_STORAGE', 1)
     endif
   endif
-
-  dep_rt = compiler.find_library('rt', required : false)
 
   if (config.get('HAVE_TIME_H', 0) == 1 and
       config.get('HAVE_STRUCT_TIMESPEC', 0) == 1 and

--- a/private_native/meson.build
+++ b/private_native/meson.build
@@ -15,9 +15,9 @@
 
 ## This file sets the config.h header for standard builds (e.g., not native: true)
 
-config_h = configure_file(
-  configuration : conf,
+config_h_native = configure_file(
+  configuration : conf_native,
   output : 'config.h',
 )
 
-inc_private = include_directories('.')
+inc_private_native = include_directories('.')

--- a/src/meson.build
+++ b/src/meson.build
@@ -28,4 +28,19 @@ libcmocka = library(
   version : lib_version,
   install : get_option('buildtype') != 'static',
   override_options : _overrides,
+  build_by_default: false,
+)
+
+libcmocka_native = library(
+  'cmocka_native',
+  ['cmocka.c'],
+  c_args : '-DHAVE_CONFIG_H=1',
+  include_directories : [inc_include, inc_private_native],
+  vs_module_defs : 'cmocka.def',
+  soversion : build_machine.system() != 'windows' ? lib_version.split('.')[0] : '',
+  version : lib_version,
+  install : false, # Cannot install native targets in cross builds
+  override_options : _overrides,
+  native: true,
+  build_by_default: false,
 )


### PR DESCRIPTION
This is necessary for cross-compilation builds, where we want to link a test program on the build machine only. Without a separate dependnecy and library, there's no way to use this library with `native: true` targets.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mesonbuild/cmocka/4)
<!-- Reviewable:end -->
