### PR TITLE
Handle config file subdirectories properly

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -39,6 +39,7 @@ cc_dict = {
     'compiler': meson.get_compiler('c'),
     'machine': host_machine,
     'config': conf,
+    'header-subdir': 'private',
     'native': false
 }
 
@@ -46,6 +47,7 @@ cc_native_dict = {
     'compiler': meson.get_compiler('c', native: true),
     'machine': build_machine,
     'config': conf_native,
+    'header-subdir': 'private_native',
     'native': true
 }
 
@@ -181,14 +183,15 @@ endif
     config.set('WORDS_BIGENDIAN', 1)
   endif
 
+  # Execute subdir to create config.h for this pass
+  subdir(entry.get('header-subdir'))
+
 endforeach
 
 ###########################
 # Subdirectory Processing #
 ###########################
 
-subdir('private')  # someplace safe to put the generated config.h file
-subdir('private_native') # someplace safe to put the generated config.h file for native: true
 subdir('src')
 
 ######################

--- a/meson.build
+++ b/meson.build
@@ -32,22 +32,17 @@ inc_include = include_directories('include')
 # Config Generation #
 #####################
 
-conf = configuration_data()
-conf_native = configuration_data()
-
 cc_dict = {
     'compiler': meson.get_compiler('c'),
     'machine': host_machine,
-    'config': conf,
-    'header-subdir': 'private',
+    'config_h_subdir': 'private',
     'native': false
 }
 
 cc_native_dict = {
     'compiler': meson.get_compiler('c', native: true),
     'machine': build_machine,
-    'config': conf_native,
-    'header-subdir': 'private_native',
+    'config_h_subdir': 'private_native',
     'native': true
 }
 
@@ -55,9 +50,10 @@ configurations = [cc_dict, cc_native_dict]
 
 foreach entry : configurations
   compiler = entry.get('compiler')
-  config = entry.get('config')
   is_native = entry.get('native')
   machine = entry.get('machine')
+
+  config = configuration_data()
 
   if ['gcc', 'clang'].contains(compiler.get_id())
     add_project_arguments(
@@ -184,7 +180,9 @@ endif
   endif
 
   # Execute subdir to create config.h for this pass
-  subdir(entry.get('header-subdir'))
+  # This requires the use of the variable named "config" for configuration_data(),
+  # as this variable is used in each configuration header subdirectory.
+  subdir(entry.get('config_h_subdir'))
 
 endforeach
 

--- a/private/meson.build
+++ b/private/meson.build
@@ -16,7 +16,7 @@
 ## This file sets the config.h header for standard builds (e.g., not native: true)
 
 config_h = configure_file(
-  configuration : conf,
+  configuration : config,
   output : 'config.h',
 )
 

--- a/private_native/meson.build
+++ b/private_native/meson.build
@@ -16,7 +16,7 @@
 ## This file sets the config.h header for standard builds (e.g., not native: true)
 
 config_h_native = configure_file(
-  configuration : conf_native,
+  configuration : config,
   output : 'config.h',
 )
 


### PR DESCRIPTION
@legeana,

With the adjustment to a loop, the variables aren't updated as they were before due to Meson having immutable variables. We need to call subdir() in the loop, and use the generic config variable for that run. I didn't realize this until I did some heavy testing across systems - OS X built fine, but Linux was suddenly failing to find headers like `signal.h`, even though they were properly detected.

With this change, I see the configuration headers populated correctly once again.